### PR TITLE
Implement compiler arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Usage
 Load extension using %load_ext cppmagic.    
 Use %%cpp at the beginning of the cell and write your C++ code. Execute to get results or compilation errors.   
 Use %%cpp -t to get a timeit result.
+Use %%cpp -- [-args...] to pass arguments to the C++ compiler. (For example, %%cpp -- -O3 -lpthread)
 
 <br><br>
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ TODO:
 --------
 - test on windows
 - test on python 2
-- add compiler flags
 - add timeit params
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Usage
 --------
 Load extension using %load_ext cppmagic.    
 Use %%cpp at the beginning of the cell and write your C++ code. Execute to get results or compilation errors.   
-Use %%cpp -t to get a timeit result.
+Use %%cpp -t to get a timeit result.  
 Use %%cpp -- [-args...] to pass arguments to the C++ compiler. (For example, %%cpp -- -O3 -lpthread)
 
 <br><br>

--- a/cppmagic.py
+++ b/cppmagic.py
@@ -13,6 +13,7 @@ def get_argparser():
     parser = argparse.ArgumentParser(description='CppMagic params')
     parser.add_argument("-t", "--timeit", action='store_true',
                         help='flag to return timeit result instead of stdout')
+    parser.add_argument("rest", nargs = argparse.REMAINDER)
     return parser
 
 
@@ -23,8 +24,9 @@ class CppMagic(ipym.Magics):
         super(CppMagic, self).__init__(shell)
         self.argparser = get_argparser()
         
-    def _compile(self, file_path):
-        subprocess.check_output(["g++", file_path + ".cpp", "-o", file_path + ".out"], stderr=subprocess.STDOUT)
+    def _compile(self, file_path, compilerOpts=None):
+        cmd = ["g++", file_path + ".cpp", "-o", file_path + ".out"] + compilerOpts[1:len(compilerOpts)]
+        subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
     def _run(self, file_path, timeit=False):
         if timeit:
@@ -48,7 +50,7 @@ class CppMagic(ipym.Magics):
             with open(file_path + ".cpp", "w") as f:
                 f.write(cell)
             try:
-                self._compile(file_path)
+                self._compile(file_path, compilerOpts = args.rest)
                 output = self._run(file_path, timeit=args.timeit)
             except subprocess.CalledProcessError as e:
                 print(e.output.decode("utf8"))


### PR DESCRIPTION
Added support for compiler arguments to g++ within the cell magic declaration. Any arguments after "--" will be passed as arguments to g++, and anything before will be passed as arguments to the cpp magic. For example, you can use "%%cpp -t -- -O3 -lpthread" at the beginning of your cell. This will run "timeit" on the cpp magic, while passing the "-O3" and "-lpthread" arguments to g++.